### PR TITLE
WIP/ENH: initial attempt to create casts

### DIFF
--- a/sphinxcontrib/autorunrecord.py
+++ b/sphinxcontrib/autorunrecord.py
@@ -42,7 +42,7 @@ class RunRecord(LiteralInclude):
         language=directives.unchanged_required,
         realcommand=directives.unchanged_required,
         workdir=directives.unchanged_required,
-        tag=directives.unchanged,
+        cast=directives.unchanged,
         caption=directives.unchanged
     )
 
@@ -75,7 +75,7 @@ class RunRecord(LiteralInclude):
             if not cast_dir.exists():
                 cast_dir.mkdir()
             # get file name where to write the cast to
-            cast = self.options.get('tag', None)
+            cast = self.options.get('cast', None)
             if cast is not None:
                 capture_file_cast = cast_dir / cast
                 self.write_cast(capture_file_cast)

--- a/sphinxcontrib/autorunrecord.py
+++ b/sphinxcontrib/autorunrecord.py
@@ -91,19 +91,10 @@ class RunRecord(LiteralInclude):
 
         # Get configuration values for the language
         args = config[language].split()
-        input_encoding = config.get(language + '_input_encoding', 'utf-8')
         output_encoding = config.get(language + '_output_encoding', 'utf-8')
-        prefix_str = config.get(language + '_prefix_str', '')
 
         # Build the code text
-        code = self.options.get('realcommand', None)
-        if code is None:
-            codelines = (
-                line[len(prefix_str):] if line.startswith(prefix_str) else line
-                for line in self.content
-            )
-            code = u'\n'.join(codelines)
-        code = code.encode(input_encoding)
+        code = self.get_code(encode=True)
 
         proc = Popen(
             args,
@@ -130,15 +121,23 @@ class RunRecord(LiteralInclude):
         capture_file.write_text(out)
 
 
-    def write_cast(self, capture_file_cast):
-        """Write a cast from tagged code examples"""
+    def get_code(self, encode=False):
+        """Extract code examples from a runrecord
+
+        Parameters
+        ----------
+        encode : bool
+            If True, encode code according to AutoRunRecords config
+        Returns
+        -------
+        code : str
+        """
+
         config = AutoRunRecord.config
         language = self.options.get('language', 'console')
         prefix_str = config.get(language + '_prefix_str', '')
+        input_encoding = config.get(language + '_input_encoding', 'utf-8')
 
-        caption = self.options.get('caption', '(no caption)')
-
-        # Build the code text; first try realcommand
         code = self.options.get('realcommand', None)
         if code is None:
             codelines = (
@@ -147,6 +146,11 @@ class RunRecord(LiteralInclude):
                 for line in self.content
             )
             code = u'\n'.join(codelines)
+        if encode:
+            code = code.encode(input_encoding)
+        return code
+
+
         # write the cast
         # TODO: make clean has to clean the casts, else we'll append and
         # append and append with every build from scratch

--- a/sphinxcontrib/autorunrecord.py
+++ b/sphinxcontrib/autorunrecord.py
@@ -68,20 +68,17 @@ class RunRecord(LiteralInclude):
                 self.config.autorunrecord_env,
             )
 
-        # TODO: do not build cast by default, rely on some sort of env
-        # variable in the flavor or CAST=True
-        # !! requires variable CAST_DIR in conf.py! for me currently:
-        # '/home/adina/repos/datalad-handbook/casts'
-        cast_dir = Path(self.config.autorunrecord_env['CAST_DIR'])
-        if not cast_dir.exists():
-            cast_dir.mkdir()
-        cast = self.options.get('tag', None)
-        if cast is not None:
-            capture_file_cast = Path(self.config.autorunrecord_env['CAST_DIR']) /\
-                                cast
-            # TODO: this needs to aggregate several snippets, without
-            # appending over and over again after each make...
-            self.write_cast(capture_file_cast)
+        # to build cast, have CAST_DIR env variable configured with path
+        cast_dir = self.config.autorunrecord_env.get('CAST_DIR')
+        if cast_dir:
+            cast_dir = Path(cast_dir)
+            if not cast_dir.exists():
+                cast_dir.mkdir()
+            # get file name where to write the cast to
+            cast = self.options.get('tag', None)
+            if cast is not None:
+                capture_file_cast = cast_dir / cast
+                self.write_cast(capture_file_cast)
 
         docnodes = super(RunRecord, self).run()
         return docnodes

--- a/sphinxcontrib/autorunrecord.py
+++ b/sphinxcontrib/autorunrecord.py
@@ -151,13 +151,20 @@ class RunRecord(LiteralInclude):
         return code
 
 
+    def write_cast(self, capture_file_cast):
+        """Write a cast from tagged code examples"""
+        import shlex
+        caption = self.options.get('caption', None)
+        code = self.get_code(encode=False)
+        # Build the code text; first try realcommand
         # write the cast
         # TODO: make clean has to clean the casts, else we'll append and
         # append and append with every build from scratch
         mode = 'a' if capture_file_cast.exists() else 'w'
         with open(capture_file_cast, mode) as f:
-            f.write('say "' + caption + '"\n')
-            f.write('run "' + code + '"\n')
+            if caption is not None:
+                f.write('say {}\n'.format(shlex.quote(caption)))
+            f.write('run {}\n'.format(shlex.quote(code)))
 
 
 def setup(app):


### PR DESCRIPTION
My first take at extending autorunrecord to create casts from code snippets.
I have added two options to the runrecord directive, ``tag`` and ``caption``. 

- If `tag` is specified, the code snippet will be written into a cast as a ``run`` section. The name of the file is defined by the specification of `tag`, i.e. ``:tag: mycast`` will write the code in the snippet into the file ``mycast`` (this makes it possible to precisely define into which casts a certain snippets should go, beyond bounderies of snippets or sections).
   - ``realcommand`` code takes precendence over code in the code-block
- If `caption` is specified, its specification will be written in the cast as a `say` section, i.e., ``:caption: Now we're creating a dataset`` will turn into ``say "Now we're creating a dataset"``
  - if `caption` is not specified (but `tag` is), the `say` section gets `"(no caption)"`

### Requirements
- an additional environment variable ``CAST_DIR`` in ``docs/conf.py``

### TODO
- [x] check whether the casts are functional (I don't know how to start them yet)
- OBSOLETE NOW extend the Makefile of the handbook to remove the casts with a clean