### PR TITLE
New option "makepushtarget" to ease creating local ds siblings

### DIFF
--- a/sphinxcontrib/autorunrecord.py
+++ b/sphinxcontrib/autorunrecord.py
@@ -228,6 +228,33 @@ class RunRecord(LiteralInclude):
             f.write('Code snippet {}::\n\n{}\n\n\n'.format(castcount,
                                                               code))
 
+def makepushtarget(ds_path,
+                   name,
+                   push_path,
+                   annex=False,
+                   bare=True):
+    """
+    Helper: create a push target to pretend a push to a sibling.
+    This will create a new repository under 'push_path', and register
+    it as a sibling of name 'name' to the dataset given with 'ds_path'
+    """
+
+    from datalad.core.distributed.tests.test_push import \
+        mk_push_target
+    from datalad.api import Dataset
+    import os.path as op
+
+    #prevent existing paths being overwritten
+    if op.exists(push_path):
+        raise Exception("The push path {} already exits!".format(push_path))
+
+    mk_push_target(ds=Dataset(ds_path),
+                   name=name,
+                   path=push_path,
+                   annex=annex,
+                   bare=bare)
+
+
 def setup(app):
     app.add_directive('runrecord', RunRecord)
     app.connect('builder-inited', AutoRunRecord.builder_init)

--- a/sphinxcontrib/autorunrecord.py
+++ b/sphinxcontrib/autorunrecord.py
@@ -153,6 +153,35 @@ class RunRecord(LiteralInclude):
         prefix_str = config.get(language + '_prefix_str', '')
         input_encoding = config.get(language + '_input_encoding', 'utf-8')
 
+        pushtarget = self.options.get('makepushtarget', None)
+        if pushtarget is not None:
+            import json
+            push_args = json.loads(pushtarget)
+            # safeguard against wrong specifications:
+            ds_path = push_args.get('ds_path', None)
+            name = push_args.get('name', None)
+            path = push_args.get('push_path',  None)
+            # can't get around quotes around 'True' or 'False' #TODO
+            annex = True if push_args.get('annex', None) == 'True' else False
+            bare = True if push_args.get('bare', None) == 'True' else False
+            if None in (ds_path, path, name):
+                raise Exception('Please specify a ds_path, push_path, a sibling name '
+                                'to create a push target. '
+                                'Your current specification is: ds_path = {}, '
+                                'push_path = {}, name = {}'.format(ds_path, name, path))
+            try:
+                makepushtarget(ds_path, name, path, annex, bare)
+            except Exception as e:
+                print(
+                """
+                Makepushtarget failed. Check for mispecified arguments.
+                Use makepushtarget with a dictionary like this:
+                {"ds_path": "/home/me/dl-101/DataLad-101/midterm_project",
+                "name": "github", "push_path": "/home/me/pushes/midtermproject",
+                "annex": "False", "bare": "True"}
+                """)
+                print('Encountered the following error: {}'.format(e))
+
         code = self.options.get('realcommand', None)
         if code is None:
             codelines = (

--- a/sphinxcontrib/autorunrecord.py
+++ b/sphinxcontrib/autorunrecord.py
@@ -42,6 +42,7 @@ class RunRecord(LiteralInclude):
         LiteralInclude.option_spec,
         language=directives.unchanged_required,
         realcommand=directives.unchanged_required,
+        makepushtarget=directives.unchanged,
         workdir=directives.unchanged_required,
         cast=directives.unchanged,
         notes=directives.unchanged


### PR DESCRIPTION
ping @mih

This is in response to https://github.com/datalad-handbook/book/pull/417#discussion_r396000284. With this option, one can set up a local push target. A complete specification looks like this:

```rst
.. runrecord:: _examples/DL-101-101-107
   :language: console
   :workdir: dl-101/DataLad-101
   :makepushtarget: {"ds_path" : "/home/me/dl-101/DataLad-101", "name" : "blubb", "push_path" : "/home/me/pushes/blubb", "annex" : "True", "bare" : "True"}
```
This will create a sibling (``name``) to a local push target (``push_path``) in the specified Dataset (``ds_path``). These three arguments are mandatory. If not ``annex`` and ``bare`` are not given, the target will by default be a bare pure Git repository. The output of the command is not recorded.

The command will raise an exception if the push target already exists (better be safe than sorry, as the path can be any path one could easily accidentally create a bare repo inside of their home directory, and that looks messy to the naked eye). Here is how it would look like if I attempt to specify push path to an existing directory:

```
reading sources... [100%] basics/101-101-create

                Makepushtarget failed. Check for mispecified arguments. 
                Use makepushtarget with a dictionary like this:
                {"ds_path": "/home/me/dl-101/DataLad-101/midterm_project",
                "name": "github", "push_path": "/home/me/pushes/midtermproject",
                "annex": "False", "bare": "True"}
                
Encountered the following error: The push path /home/me/pushes/blubb5 already exits!

looking for now-outdated files... none found
pickling environment... done

```

Any feedback welcome!