### PR TITLE
Change from line buffering to default buffer 

### DIFF
--- a/sphinxcontrib/autorunrecord.py
+++ b/sphinxcontrib/autorunrecord.py
@@ -112,7 +112,7 @@ class RunRecord(LiteralInclude):
 
         proc = Popen(
             args,
-            bufsize=1,
+            bufsize=-1,
             stdin=PIPE,
             stdout=PIPE,
             # capture both in a merged stream


### PR DESCRIPTION
A recent Python version (I think 3.8) introduced a warning that line buffering
isn't supported in binary mode: https://github.com/python/cpython/commit/a2670565d8f5c502388378aba1fe73023fd8c8d4
In the handbook, this results in a flood of warning messages - one for every
runrecord that I write (See https://github.com/datalad-handbook/book/issues/568)
With this change, I switch from line buffering (1) to using the default buffer
(-1).

ping @mih.
